### PR TITLE
Add MacPorts Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@
 
 ## Installing
 
-SentiPy can be installed with [pip](https://pip.pypa.io/en/stable/)
+SentiPy can be installed with [pip](https://pip.pypa.io/en/stable/):
 
 ```
 $ python3 -m pip install sentiment-investor
+```
+
+On macOS, it can also be installed via [MacPorts](https://ports.macports.org/port/py-sentipy/):
+
+```
+$ sudo port install py-sentipy
 ```
 
 ## Setup


### PR DESCRIPTION
Hi there 👋 

Following https://github.com/macports/macports-ports/commit/53500edd5b33c5ad0d130e7d0c5cba29088a3cf3, sentipy has been added to [MacPorts](https://ports.macports.org/port/py-sentipy/)! It can now be installed on macOS by running the following:

```
$ sudo port install py-sentipy
```

I thought I'd note this in the docs. Thanks for maintining the project.