### PR TITLE
Improve Google Docstring compliance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,4 @@ jobs:
         run: |
           poetry run black --check .
           poetry run isort --check-only .
+          poetry run pydocstyle --convention=google .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,14 @@ repos:
 
   - repo: local
     hooks:
+    - id: pydocstyle
+      name: pydocstyle
+      entry: poetry run pydocstyle --convention=google
+      types: [python]
+      language: system
+
+  - repo: local
+    hooks:
       - id: isort
         name: isort
         entry: poetry run isort

--- a/poetry.lock
+++ b/poetry.lock
@@ -227,6 +227,20 @@ toml = "*"
 virtualenv = ">=20.0.8"
 
 [[package]]
+name = "pydocstyle"
+version = "6.1.1"
+description = "Python docstring style checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+snowballstemmer = "*"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -267,6 +281,14 @@ description = "Python 2 and 3 compatibility utilities"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "snowballstemmer"
+version = "2.1.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "toml"
@@ -377,7 +399,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5e13963f8f6f6ff401213c243aaf7749860b756fd01014e50ddae83e463b4bba"
+content-hash = "601456f027e6b745c7856bc030840fd7185bf702e8357590c770a0a577b7a03d"
 
 [metadata.files]
 appdirs = [
@@ -520,6 +542,10 @@ pre-commit = [
     {file = "pre_commit-2.13.0-py2.py3-none-any.whl", hash = "sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4"},
     {file = "pre_commit-2.13.0.tar.gz", hash = "sha256:764972c60693dc668ba8e86eb29654ec3144501310f7198742a767bec385a378"},
 ]
+pydocstyle = [
+    {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
+    {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
+]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
     {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
@@ -601,6 +627,10 @@ requests = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+snowballstemmer = [
+    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
+    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ black = "^21.7b0"
 isort = "^5.9.2"
 pre-commit = "^2.13.0"
 vcrpy = "^4.1.1"
+pydocstyle = "^6.1.1"
 
 [tool.isort]
 profile = "black"

--- a/sentipy/__init__.py
+++ b/sentipy/__init__.py
@@ -1,3 +1,8 @@
+"""The Sentipy module provides a simple and lightweight way to interact with the SentimentInvestor API and data.
+
+For more information, please visit https://docs.sentimentinvestor.com/python/
+"""
+
 from . import sentipy
 
 __all__ = ["sentipy", "ws"]

--- a/sentipy/_typing_imports.py
+++ b/sentipy/_typing_imports.py
@@ -1,4 +1,4 @@
-"""Use typing module where required for python < 3.9, and define additional types.
+"""Use typing module where required for python < 3.9, and defines additional types.
 
 This deals with the typing module being depreciated.
 """

--- a/sentipy/sentipy.py
+++ b/sentipy/sentipy.py
@@ -1,3 +1,10 @@
+"""The Sentiment Investor Python Client library.
+
+This provides the main Senipy object, through which you can authenticate yourself.
+
+For more information, please visit https://docs.sentimentinvestor.com/python/
+"""
+
 import enum
 import json
 from typing import Optional, Union
@@ -9,6 +16,8 @@ from sentipy._typing_imports import DictType, JSONType, ListType, SetType, Tuple
 
 
 class AccountTier(enum.Enum):
+    """Defines which tier the user's Sentiment Investor account is."""
+
     SANDBOX = 0
     STARTER = 1
     PREMIUM = 1.5
@@ -16,8 +25,8 @@ class AccountTier(enum.Enum):
 
 
 class _ApiResponse:
-    """
-    Specifies a basic data item for a specific ticker.
+    """Specifies a basic data item for a specific ticker.
+
     .. attention:: Do not try to initialise one yourself.
     """
 
@@ -35,8 +44,8 @@ class _ApiResponse:
 
 
 class _ApiResult(_ApiResponse):
-    """
-    For a list of available metrics, use `dir(object)`
+    """For a list of available metrics, use `dir(object)`.
+
     .. attention:: Returned by quote, do not try to initialise one yourself.
     """
 
@@ -48,14 +57,7 @@ class _ApiResult(_ApiResponse):
 
 
 class Sentipy:
-    """
-    The Sentipy module provides a simple and lightweight way to interact with the SentimentInvestor API and data.
-
-    Sentipy is installed through [pip](https://pip.pypa.io/)
-    ```
-    $ python3 -m pip install sentiment-investor
-    ```
-    """
+    """This defines the main Sentipy object through which the user authenticates themselves."""
 
     base_url = r"https://api.sentimentinvestor.com/v4/"
     """
@@ -64,8 +66,7 @@ class Sentipy:
 
     @beartype
     def __init__(self, token: str, key: str) -> None:
-        """
-        Initialise a new SentiPy instance with your token and key
+        """Initialise a new SentiPy instance with your token and key.
 
         Examples:
             >>> token = "my-very-secret-token"
@@ -73,8 +74,8 @@ class Sentipy:
             >>> sentipy = Sentipy(token=token, key=key)
 
         Args:
-            token (str): API token from the SentimentInvestor website
-            key (str): API key from the SentimentInvestor website
+            token: API token from the SentimentInvestor website
+            key: API key from the SentimentInvestor website
 
         Raises:
             `ValueError` if either `token` or `key` not provided
@@ -86,12 +87,11 @@ class Sentipy:
     def _base_request(
         self, endpoint: str, params: Optional[JSONType] = None
     ) -> JSONType:
-        """
-        Make a request to a specific REST endpoint on the SentimentInvestor API
+        """Make a request to a specific REST endpoint on the SentimentInvestor API.
 
         Args:
-            endpoint (str): the REST endpoint (final fragment in URL)
-            params (dict): any supplementary parameters to pass to the API
+            endpoint: the REST endpoint (final fragment in URL)
+            params: any supplementary parameters to pass to the API
 
         Returns: the JSON response if the request was successful, otherwise an exception is raised.
 
@@ -120,11 +120,10 @@ class Sentipy:
 
     @beartype
     def parsed(self, symbol: str) -> _ApiResult:
-        """
-        The parsed data endpoints provides the four core metrics for a stock: AHI, RHI, SGP and sentiment.
+        """The parsed data endpoints provides the four core metrics for a stock: AHI, RHI, SGP and sentiment.
 
         Args:
-            symbol (str): string specifying the ticker or symbol of the stock to request data for
+            symbol: string specifying the ticker or symbol of the stock to request data for
 
         Returns: a QuoteData object
 
@@ -140,11 +139,10 @@ class Sentipy:
 
     @beartype
     def raw(self, symbol: str) -> _ApiResult:
-        """
-        The raw data endpoint provides access to raw data metrics for the monitored social platforms
+        """The raw data endpoint provides access to raw data metrics for the monitored social platforms.
 
         Args:
-            symbol (str): ticker or symbol of the stock to request data for
+            symbol: ticker or symbol of the stock to request data for
 
         Returns: a QuoteData object
 
@@ -155,12 +153,11 @@ class Sentipy:
 
     @beartype
     def quote(self, symbol: str, enrich: bool = False) -> _ApiResult:
-        """
-        The quote data endpoint provides access to all realtime data about stocks along with further data if requested
+        """The quote data endpoint provides access to all realtime data about stocks along with further data if requested.
 
         Args:
-            symbol (str): ticker or symbol of the stock to request data for
-            enrich (bool): whether to request enriched data
+            symbol: ticker or symbol of the stock to request data for
+            enrich: whether to request enriched data
 
         Returns: a QuoteData object
 
@@ -206,12 +203,11 @@ class Sentipy:
 
     @beartype
     def sort(self, metric: str, limit: int) -> ListType[_ApiResponse]:
-        """
-        The sort data endpoint provides access to ordered rankings of stocks across core metrics
+        """The sort data endpoint provides access to ordered rankings of stocks across core metrics.
 
         Args:
-            metric (str): the metric by which to sort the stocks
-            limit (int): the maximum number of stocks to return
+            metric: the metric by which to sort the stocks
+            limit: the maximum number of stocks to return
 
         Returns: a list of TickerData objects
 
@@ -237,14 +233,13 @@ class Sentipy:
     def historical(
         self, symbol: str, metric: str, start: int, end: int
     ) -> DictType[Union[int, float], Union[int, float]]:
-        """
-        The historical data endpoint provides access to historical data for stocks
+        """The historical data endpoint provides access to historical data for stocks.
 
         Args:
-            symbol (str): the stock to look up historical data for
-            metric (str): the metric for which to return data
-            start (int): Unix epoch timestamp in seconds specifying start of date range
-            end (int): Unix epoch timestamp in seconds specifying end of date range
+            symbol: the stock to look up historical data for
+            metric: the metric for which to return data
+            start: Unix epoch timestamp in seconds specifying start of date range
+            end: Unix epoch timestamp in seconds specifying end of date range
 
         Returns (dict): a dictionary of (timestamp -> data entry) mappings.
 
@@ -269,12 +264,11 @@ class Sentipy:
     def bulk(
         self, symbols: ListType[str], enrich: bool = False
     ) -> ListType[_ApiResponse]:
-        """
-        Get quote data for several stocks simultaneously
+        """Get quote data for several stocks simultaneously.
 
         Args:
-            symbols (iterable): list of stocks to get quote data for
-            enrich (bool): whether to get enriched data
+            symbols: list of stocks to get quote data for
+            enrich: whether to get enriched data
 
         Returns: a list of TickerData objects
 
@@ -288,13 +282,12 @@ class Sentipy:
 
     @beartype
     def all(self, enrich: bool = False) -> ListType[_ApiResponse]:
-        """
-        Get all data for all stocks simultaneously.
+        """Get all data for all stocks simultaneously.
 
         .. note:: this blocking call takes a long time to execute.
 
         Args:
-            enrich (bool): whether to fetch enriched data
+            enrich: whether to fetch enriched data
 
         Returns: a list of TickerData objects
 
@@ -308,11 +301,10 @@ class Sentipy:
 
     @beartype
     def supported(self, symbol: str) -> bool:
-        """
-        Query whether SentimentInvestor has data for a specified stock
+        """Query whether SentimentInvestor has data for a specified stock.
 
         Args:
-            symbol (str): stock ticker symbol to query
+            symbol: stock ticker symbol to query
 
         Returns: boolean whether supported or not
 
@@ -331,8 +323,7 @@ class Sentipy:
 
     @beartype
     def all_stocks(self) -> SetType[str]:
-        """
-        Get a list of all stocks for which Sentiment gather data
+        """Get a list of all stocks for which Sentiment gather data.
 
         Returns (set[str]): list of stock symbols
 
@@ -344,9 +335,19 @@ class Sentipy:
     @property  # type: ignore[misc]
     @beartype
     def account_info(self) -> Optional[_ApiResponse]:
+        """Provides information about the user's account.
+
+        Returns:
+            The api response about the user's account
+        """
         return _ApiResponse(self._base_request("account"))
 
     @property  # type: ignore[misc]
     @beartype
     def api_credentials(self) -> TupleType[str, str]:
+        """Provides the user's api credentials.
+
+        Returns:
+            The user's api token and key
+        """
         return self.token, self.key

--- a/sentipy/sentipy.py
+++ b/sentipy/sentipy.py
@@ -1,6 +1,6 @@
 """The Sentiment Investor Python Client library.
 
-This provides the main Senipy object, through which you can authenticate yourself.
+This provides the main SentiPy object, through which you can authenticate yourself.
 
 For more information, please visit https://docs.sentimentinvestor.com/python/
 """
@@ -57,7 +57,7 @@ class _ApiResult(_ApiResponse):
 
 
 class Sentipy:
-    """This defines the main Sentipy object through which the user authenticates themselves."""
+    """This defines the main SentiPy object through which the user authenticates themselves."""
 
     base_url = r"https://api.sentimentinvestor.com/v4/"
     """

--- a/sentipy/ws.py
+++ b/sentipy/ws.py
@@ -143,7 +143,7 @@ class _Stream:
     def reconnect(self) -> None:
         """Manually request a websocket reconnection.
 
-        This should not usually be necessary as Sentipy will try to reconnect automatically if connection is lost.
+        This should not usually be necessary as SentiPy will try to reconnect automatically if connection is lost.
         """
         self.__connect()
 

--- a/sentipy/ws.py
+++ b/sentipy/ws.py
@@ -1,3 +1,8 @@
+"""This provides websocket support for Sentiment Investor.
+
+For more information, please visit https://docs.sentimentinvestor.com/RESTful/websocket
+"""
+
 # TODO: Refactor to use the threading library
 import _thread as thread
 import datetime
@@ -16,13 +21,14 @@ from ._typing_imports import DictType, IterableType
 
 # Defined at the top since it's used in type annotations
 class StockUpdateData:
+    """A new data container for the stock update."""
+
     @beartype
     def __init__(self, message: str) -> None:
-        """
-        Initialise a new data container for the stock update
+        """Defines attributes from the message for the new container.
 
         Args:
-            A JSON string returned by the websocket server
+            message: A JSON string returned by the websocket server
         """
         for k, v in json.loads(message).items():
             setattr(self, k, v)
@@ -33,9 +39,7 @@ CallableType = Callable[[StockUpdateData], None]
 
 
 class _Stream:
-    """
-    Base class for different kinds of websocket streams
-    """
+    """Base class for different kinds of websocket streams."""
 
     base_url = "ws://socket.sentimentinvestor.com/"
     """
@@ -49,12 +53,11 @@ class _Stream:
     def __init__(
         self, token: str, key: str, callback: CallableType, fragment: str
     ) -> None:
-        """
-        Initialise a new web socket stream
+        """Initialise a new web socket stream.
 
         Args:
-            token (str): SentimentInvestor API token
-            key (str): SentimentInvestor API key
+            token: SentimentInvestor API token
+            key: SentimentInvestor API key
             callback: function accepting one argument of type `StockUpdateData` that is called when data is received
             fragment: the websocket endpoint to contact
 
@@ -138,14 +141,16 @@ class _Stream:
 
     @beartype
     def reconnect(self) -> None:
-        """
-        Manually request a websocket reconnection.
-        This should not usually be necessary as Sentipy will try to reconnect automatically if connection is lost
+        """Manually request a websocket reconnection.
+
+        This should not usually be necessary as Sentipy will try to reconnect automatically if connection is lost.
         """
         self.__connect()
 
 
 class StocksStream(_Stream):
+    """A WebSocket listener for specific stocks."""
+
     @beartype
     def __init__(
         self,
@@ -154,8 +159,7 @@ class StocksStream(_Stream):
         callback: CallableType,
         symbols: Optional[IterableType[str]] = None,
     ) -> None:
-        """
-        Initialise a new WebSocket listener for specific stocks
+        """Initialises the new websocket listener.
 
         Args:
             symbols: an iterable of symbols specifying which stock changes to listen for
@@ -169,10 +173,11 @@ class StocksStream(_Stream):
 
 
 class AllStocksStream(_Stream):
+    """A WebSocket listener for all available stocks."""
+
     @beartype
     def __init__(self, token: str, key: str, callback: CallableType) -> None:
-        """
-        Initialise a new WebSocket listener for all available stocks
+        """Initialises the new websocket listener.
 
         Args:
             token: SentimentInvestor API token

--- a/tests/sentipy_tests.py
+++ b/tests/sentipy_tests.py
@@ -1,3 +1,5 @@
+"""Tests various methods of the sentipy module."""
+
 import os
 import unittest
 
@@ -11,11 +13,13 @@ from sentipy.sentipy import Sentipy
 
 
 class SentipyTestCase(unittest.TestCase):
+    """Testing class for the sentipy module."""
+
     sentipy: Sentipy
 
     @beartype
     def setUp(self) -> None:
-
+        """Checks whether the key and token have been defined, and then authenticates."""
         sentipy_key = os.getenv("API_SENTIMENTINVESTOR_KEY")
         sentipy_token = os.getenv("API_SENTIMENTINVESTOR_TOKEN")
 
@@ -32,17 +36,43 @@ class SentipyTestCase(unittest.TestCase):
 
     @beartype
     def assertHasAttr(self, object: DictType[str, str], attr: str) -> None:
+        """Checks whether a dictionary has a certain attribute or not.
+
+        Args:
+            object: The dictionary to search for the attribute
+            attr: Which attribute to search for in the object
+
+        Raises:
+            AssertionError: If the attribute is not in the object
+        """
         self.assertTrue(
             hasattr(object, attr), f"{object!r} does not have attribute {attr!r}"
         )
 
     @beartype
     def assertHasAttrs(self, object: DictType[str, str], attrs: ListType[str]) -> None:
+        """Checks whether a dictionary has certain attributes or not.
+
+        Args:
+            object: The dictionary to search for the attribute
+            attrs: Which attributes to search for in the object
+
+        Raises:
+            AssertionError: If any of the attributes aren't in the object
+        """
         for attr in attrs:
             self.assertHasAttr(object, attr)
 
     @beartype
     def check_basics(self, data: object) -> None:
+        """Checks whether the api response was successful.
+
+        Args:
+            data: The response from the Sentiment Investor API
+
+        Raises:
+            AssertionError: If the response was not successful.
+        """
         # The data will have a success attribute
         self.assertTrue(data.success)  # type: ignore[attr-defined]
         self.assertHasAttr(data, "symbol")
@@ -50,6 +80,7 @@ class SentipyTestCase(unittest.TestCase):
     @vcr.use_cassette("vcr_cassettes/parsed.yml")  # type: ignore[misc]
     @beartype
     def test_parsed(self) -> None:
+        """Tests sentipy's parsed attribute."""
         data = self.sentipy.parsed("AAPL")
         self.check_basics(data)
         self.assertHasAttrs(data, ["sentiment", "AHI", "RHI", "SGP"])
@@ -57,6 +88,7 @@ class SentipyTestCase(unittest.TestCase):
     @vcr.use_cassette("vcr_cassettes/raw.yml")  # type: ignore[misc]
     @beartype
     def test_raw(self) -> None:
+        """Tests sentipy's raw attribute."""
         data = self.sentipy.raw("AAPL")
         self.check_basics(data)
         self.assertHasAttrs(
@@ -77,6 +109,7 @@ class SentipyTestCase(unittest.TestCase):
 
     @vcr.use_cassette("vcr_cassettes/quote.yml")  # type: ignore[misc]
     def test_quote(self) -> None:
+        """Tests sentipy's quote attribute."""
         data = self.sentipy.quote("AAPL")
         self.check_basics(data)
         self.assertHasAttrs(
@@ -102,6 +135,7 @@ class SentipyTestCase(unittest.TestCase):
     @vcr.use_cassette("vcr_cassettes/bulk.yml")  # type: ignore[misc]
     @beartype
     def test_bulk(self) -> None:
+        """Tests sentipy's bulk attribute."""
         data = self.sentipy.bulk(["AAPL", "TSLA", "PYPL"])
         self.assertEqual(len(data), 3)
         for stock in data:

--- a/tests/sentipy_tests.py
+++ b/tests/sentipy_tests.py
@@ -1,4 +1,4 @@
-"""Tests various methods of the sentipy module."""
+"""Tests various methods of the SentiPy module."""
 
 import os
 import unittest
@@ -13,7 +13,7 @@ from sentipy.sentipy import Sentipy
 
 
 class SentipyTestCase(unittest.TestCase):
-    """Testing class for the sentipy module."""
+    """Testing class for the SentiPy module."""
 
     sentipy: Sentipy
 
@@ -80,7 +80,7 @@ class SentipyTestCase(unittest.TestCase):
     @vcr.use_cassette("vcr_cassettes/parsed.yml")  # type: ignore[misc]
     @beartype
     def test_parsed(self) -> None:
-        """Tests sentipy's parsed attribute."""
+        """Tests SentiPy's parsed attribute."""
         data = self.sentipy.parsed("AAPL")
         self.check_basics(data)
         self.assertHasAttrs(data, ["sentiment", "AHI", "RHI", "SGP"])
@@ -88,7 +88,7 @@ class SentipyTestCase(unittest.TestCase):
     @vcr.use_cassette("vcr_cassettes/raw.yml")  # type: ignore[misc]
     @beartype
     def test_raw(self) -> None:
-        """Tests sentipy's raw attribute."""
+        """Tests SentiPy's raw attribute."""
         data = self.sentipy.raw("AAPL")
         self.check_basics(data)
         self.assertHasAttrs(
@@ -109,7 +109,7 @@ class SentipyTestCase(unittest.TestCase):
 
     @vcr.use_cassette("vcr_cassettes/quote.yml")  # type: ignore[misc]
     def test_quote(self) -> None:
-        """Tests sentipy's quote attribute."""
+        """Tests SentiPy's quote attribute."""
         data = self.sentipy.quote("AAPL")
         self.check_basics(data)
         self.assertHasAttrs(
@@ -135,7 +135,7 @@ class SentipyTestCase(unittest.TestCase):
     @vcr.use_cassette("vcr_cassettes/bulk.yml")  # type: ignore[misc]
     @beartype
     def test_bulk(self) -> None:
-        """Tests sentipy's bulk attribute."""
+        """Tests SentiPy's bulk attribute."""
         data = self.sentipy.bulk(["AAPL", "TSLA", "PYPL"])
         self.assertEqual(len(data), 3)
         for stock in data:


### PR DESCRIPTION
This PR implements the following:

- Module-level docstrings added, explaining what each file does.
- Missing method docstrings were added.
- Improved compliance with the [Google-style docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
- This is then enforced via [pydocstyle](https://github.com/PyCQA/pydocstyle) in both the pre-commit hook and the GitHub action.